### PR TITLE
Add gh action to publish nptest package on push and release

### DIFF
--- a/.github/workflows/docker-publish-nptest.yml
+++ b/.github/workflows/docker-publish-nptest.yml
@@ -1,0 +1,42 @@
+name: Build and Push Docker Image for network/benchmarks/netperf/nptest
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [published, edited]
+
+jobs:
+  build-and-push:
+    permissions:
+      packages: write # Write permission is required to publish Docker images to GitHub Container Registry
+      contents: read
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      run: |
+        cd network/benchmarks/netperf
+        make push
+      env:
+        DOCKERREPO: ghcr.io/${{ github.repository_owner }}/nptest
+        # IMAGE_TAG would be commit id if push else tag if release
+        IMAGE_TAG: ${{ github.event_name == 'push' && github.sha || github.event.release.tag_name }}

--- a/.github/workflows/docker-publish-nptest.yml
+++ b/.github/workflows/docker-publish-nptest.yml
@@ -2,11 +2,9 @@ name: Build and Push Docker Image for network/benchmarks/netperf/nptest
 
 on:
   push:
-    branches:
-      - master
-  release:
-    types: [published, edited]
-
+    tags:
+      - '**'
+  
 jobs:
   build-and-push:
     permissions:
@@ -38,5 +36,4 @@ jobs:
         make push
       env:
         DOCKERREPO: ghcr.io/${{ github.repository_owner }}/nptest
-        # IMAGE_TAG would be commit id if push else tag if release
-        IMAGE_TAG: ${{ github.event_name == 'push' && github.sha || github.event.release.tag_name }}
+        IMAGE_TAG: ${{ github.ref_name }}

--- a/network/benchmarks/netperf/Makefile
+++ b/network/benchmarks/netperf/Makefile
@@ -15,14 +15,15 @@
 all: docker push launch runtests
 
 DOCKERREPO := $(or $(DOCKERREPO), girishkalele/netperf-latest)
+IMAGE_TAG := $(or $(IMAGE_TAG), latest)
 
-docker: launch
+docker: test
 	mkdir -p Dockerbuild && \
 	cp -rf nptest/* Dockerbuild/ && \
-	docker build -t $(DOCKERREPO) Dockerbuild/
+	docker build -t $(DOCKERREPO):$(IMAGE_TAG) Dockerbuild/
 
 push: docker
-	gcloud docker push $(DOCKERREPO)
+	docker push $(DOCKERREPO):$(IMAGE_TAG)
 
 clean:
 	@rm -f Dockerbuild/*
@@ -33,6 +34,10 @@ clean:
 launch: launch.go
 	go build -o launch launch.go
 
+test:
+	go test ./...
+	cd nptest && go test ./...
+
 # 'runtests' is the test runner target
 runtests: launch
 	@echo Launching network performance tests
@@ -42,7 +47,5 @@ runtests: launch
 	@echo Results file netperf-latest.csv and SVG/PNG graphs generated successfully
 
 localtest: docker
-	docker push $(DOCKERREPO)
-	go run launch.go -image=$(DOCKERREPO) -json -kubeConfig ./kubeConfig
-
-
+	docker push $(DOCKERREPO):$(IMAGE_TAG)
+	go run launch.go -image=$(DOCKERREPO):$(IMAGE_TAG) -json -kubeConfig ./kubeConfig

--- a/network/benchmarks/netperf/nptest/Dockerfile
+++ b/network/benchmarks/netperf/nptest/Dockerfile
@@ -52,6 +52,12 @@ RUN cd iperf-3.1 && ./configure --prefix=/usr/local --bindir /usr/local/bin && m
 RUN curl -LO https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz && tar -xzf netperf-2.7.0.tar.gz && mv netperf-netperf-2.7.0/ netperf-2.7.0
 RUN cd netperf-2.7.0 && ./configure --prefix=/usr/local --bindir /usr/local/bin && make CFLAGS=-fcommon && make install
 
+# Validate the installation of qperf, iperf3 and netperf
+RUN usr/local/bin/qperf --help
+RUN usr/local/bin/iperf3 -v
+RUN usr/local/bin/netperf -V
+RUN usr/local/bin/netserver -V
+
 COPY --from=builder /workspace/nptests /usr/bin/
 
 ENTRYPOINT ["nptests"]


### PR DESCRIPTION
This pull request includes several changes to automate the Docker image build and push process for the `network/benchmarks/netperf/nptest` project and to improve the Makefile for better Docker image tagging and testing. The most important changes include adding a GitHub Actions workflow for building and pushing Docker images, updating the Makefile to handle image tagging and testing, and validating the installation of necessary tools in the Dockerfile.

Automation and CI/CD:

* [`.github/workflows/docker-publish-nptest.yml`](diffhunk://#diff-b6f33a8649711bc90818fa3904c2ed4b2f12d31442e3a05e76b5f94dc2c22120R1-R42): Added a GitHub Actions workflow to build and push Docker images to the GitHub Container Registry on push to the master branch or release events.

Makefile improvements:

* [`network/benchmarks/netperf/Makefile`](diffhunk://#diff-63f3ab2658a67125310536308223e72fbce03adfd98843c14b6eb25a9ca44c64R18-R26): Updated the `docker` and `push` targets to use `IMAGE_TAG` for tagging Docker images. Added a `test` target to run tests. [[1]](diffhunk://#diff-63f3ab2658a67125310536308223e72fbce03adfd98843c14b6eb25a9ca44c64R18-R26) [[2]](diffhunk://#diff-63f3ab2658a67125310536308223e72fbce03adfd98843c14b6eb25a9ca44c64R37-R40)
* [`network/benchmarks/netperf/Makefile`](diffhunk://#diff-63f3ab2658a67125310536308223e72fbce03adfd98843c14b6eb25a9ca44c64L45-R51): Modified the `localtest` target to use `IMAGE_TAG` for Docker image tagging.

Dockerfile validation:

* [`network/benchmarks/netperf/nptest/Dockerfile`](diffhunk://#diff-691583df4b74031ea35cb3859dc4c2520efd970f99e665234f2490a35ac5a1faR55-R60): Added commands to validate the installation of `qperf`, `iperf3`, and `netperf` tools.