### PR TITLE
fix(nptest): change docker image name to use lowercase repo owner

### DIFF
--- a/.github/workflows/docker-publish-nptest.yml
+++ b/.github/workflows/docker-publish-nptest.yml
@@ -35,5 +35,5 @@ jobs:
         cd network/benchmarks/netperf
         make push
       env:
-        DOCKERREPO: ghcr.io/${{ github.repository_owner }}/nptest
+        DOCKERREPO: ghcr.io/${{ github.repository_owner.toLowerCase }}/nptest
         IMAGE_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/docker-publish-nptest.yml` file. The change ensures that the Docker repository owner is converted to lowercase, which can help avoid issues with case sensitivity in repository names.

* [`.github/workflows/docker-publish-nptest.yml`](diffhunk://#diff-b6f33a8649711bc90818fa3904c2ed4b2f12d31442e3a05e76b5f94dc2c22120L38-R38): Modified the `DOCKERREPO` environment variable to convert `github.repository_owner` to lowercase.