### PR TITLE
Revert "fix(nptest): change docker image name to use lowercase repo owner"

### DIFF
--- a/.github/workflows/docker-publish-nptest.yml
+++ b/.github/workflows/docker-publish-nptest.yml
@@ -35,5 +35,5 @@ jobs:
         cd network/benchmarks/netperf
         make push
       env:
-        DOCKERREPO: ghcr.io/${{ github.repository_owner.toLowerCase }}/nptest
+        DOCKERREPO: ghcr.io/${{ github.repository_owner }}/nptest
         IMAGE_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
Reverts Azure/perf-tests#5 as the `toLowerCase` function doesn't work. Sorry for testing it on personal fork

This pull request includes a minor change to the `.github/workflows/docker-publish-nptest.yml` file. The change modifies the `DOCKERREPO` environment variable to use the `github.repository_owner` directly instead of converting it to lowercase.

* [`.github/workflows/docker-publish-nptest.yml`](diffhunk://#diff-b6f33a8649711bc90818fa3904c2ed4b2f12d31442e3a05e76b5f94dc2c22120L38-R38): Updated the `DOCKERREPO` environment variable to use `github.repository_owner` without converting it to lowercase.