### PR TITLE
fix: make changes to makefile to convert repo_owner to lower case

### DIFF
--- a/.github/workflows/docker-publish-nptest.yml
+++ b/.github/workflows/docker-publish-nptest.yml
@@ -35,5 +35,5 @@ jobs:
         cd network/benchmarks/netperf
         make push
       env:
-        DOCKERREPO: ghcr.io/${{ github.repository_owner.toLowerCase }}/nptest
+        REPO_OWNER: ${{ github.repository_owner }}
         IMAGE_TAG: ${{ github.ref_name }}

--- a/network/benchmarks/netperf/Makefile
+++ b/network/benchmarks/netperf/Makefile
@@ -14,16 +14,17 @@
 
 all: docker push launch runtests
 
-DOCKERREPO := $(or $(DOCKERREPO), girishkalele/netperf-latest)
-IMAGE_TAG := $(or $(IMAGE_TAG), latest)
+repo_owner := $(shell echo $(REPO_OWNER) | tr '[:upper:]' '[:lower:]')
+dockerrepo := $(if $(repo_owner), ghcr.io/$(repo_owner)/nptest, girishkalele/netperf-latest)
+image_tag := $(or $(IMAGE_TAG), latest)
 
 docker: test
 	mkdir -p Dockerbuild && \
 	cp -rf nptest/* Dockerbuild/ && \
-	docker build -t $(DOCKERREPO):$(IMAGE_TAG) Dockerbuild/
+	docker build -t $(dockerrepo):$(image_tag) Dockerbuild/
 
 push: docker
-	docker push $(DOCKERREPO):$(IMAGE_TAG)
+	docker push $(dockerrepo):$(image_tag)
 
 clean:
 	@rm -f Dockerbuild/*
@@ -46,6 +47,6 @@ runtests: launch
 	cp netperf-latest.csv plotperf && cd plotperf; make plot && mv *png .. && mv *svg ..
 	@echo Results file netperf-latest.csv and SVG/PNG graphs generated successfully
 
-localtest: docker
-	docker push $(DOCKERREPO):$(IMAGE_TAG)
-	go run launch.go -image=$(DOCKERREPO):$(IMAGE_TAG) -json -kubeConfig ./kubeConfig
+localtest: push
+	go run launch.go -image=$(dockerrepo):$(image_tag) -json -kubeConfig ./kubeConfig
+


### PR DESCRIPTION
This pull request includes updates to the Docker image building and pushing process in the `network/benchmarks/netperf` project. The changes primarily focus on standardizing environment variables and improving the Makefile's logic for Docker operations.

### Environment Variable Standardization:
* [`.github/workflows/docker-publish-nptest.yml`](diffhunk://#diff-b6f33a8649711bc90818fa3904c2ed4b2f12d31442e3a05e76b5f94dc2c22120L38-R38): Replaced `DOCKERREPO` with `REPO_OWNER` to standardize environment variable naming.

### Makefile Improvements:
* `network/benchmarks/netperf/Makefile`: 
  * Introduced `repo_owner` and `dockerrepo` variables to dynamically construct the Docker repository name using the `REPO_OWNER` environment variable.
  * Updated Docker build and push commands to use the new `dockerrepo` and `image_tag` variables.
  * Modified the `localtest` target to depend on the `push` target, ensuring the image is pushed before running tests.