### PR TITLE
fix: resiliency and logging for network benchmark tests

### DIFF
--- a/network/benchmarks/netperf/Makefile
+++ b/network/benchmarks/netperf/Makefile
@@ -15,7 +15,7 @@
 all: docker push launch runtests
 
 repo_owner := $(shell echo $(REPO_OWNER) | tr '[:upper:]' '[:lower:]')
-dockerrepo := $(if $(repo_owner), ghcr.io/$(repo_owner)/nptest, girishkalele/netperf-latest)
+dockerrepo := $(if $(repo_owner),ghcr.io/$(repo_owner)/nptest,girishkalele/netperf-latest)
 image_tag := $(or $(IMAGE_TAG), latest)
 
 docker: test

--- a/network/benchmarks/netperf/nptest/Dockerfile
+++ b/network/benchmarks/netperf/nptest/Dockerfile
@@ -31,6 +31,8 @@ RUN go build -o nptests
 FROM debian:bullseye
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
+LABEL org.opencontainers.image.description "Network performance tests in k8s engine"
+
 # install binary and remove cache
 RUN apt-get update \
     && apt-get install -y  curl wget net-tools gcc make libsctp-dev git autotools-dev automake \


### PR DESCRIPTION
This pull request includes several improvements to the network benchmarks for better error handling and logging. The most important changes include adding retries with backoff for log retrieval, improving error handling when fetching the orchestrator pod name, and adding a description label to the Dockerfile.

Error handling and logging improvements:

* [`network/benchmarks/netperf/lib/outputlib.go`](diffhunk://#diff-819231a678af43480e19943e952882b0c144f51bebf74ada937f7e05ef111efeR11-R27): Added retries with backoff for retrieving logs from a pod to handle intermittent network issues.
* [`network/benchmarks/netperf/lib/utilslib.go`](diffhunk://#diff-24ea08d78b64d11a9970f12494b03f14c0209d45e614f5dff0e83eeb37e0cdb1L245-R248): Improved error handling in `executeTests` function by checking for errors when fetching the orchestrator pod name.
* [`network/benchmarks/netperf/lib/utilslib.go`](diffhunk://#diff-24ea08d78b64d11a9970f12494b03f14c0209d45e614f5dff0e83eeb37e0cdb1L293-R326): Enhanced `getOrchestratorPodName` function to handle pod creation failures and log relevant events.

Dockerfile update:

* [`network/benchmarks/netperf/nptest/Dockerfile`](diffhunk://#diff-691583df4b74031ea35cb3859dc4c2520efd970f99e665234f2490a35ac5a1faR34-R35): Added a description label to provide more context about the Docker image.