### PR TITLE
Add a metric to track job creation to pod creation time.

### DIFF
--- a/clusterloader2/pkg/framework/client/objects.go
+++ b/clusterloader2/pkg/framework/client/objects.go
@@ -251,18 +251,22 @@ func WaitForDeleteNamespace(c clientset.Interface, namespace string, timeout tim
 	return wait.PollImmediate(defaultNamespaceDeletionInterval, timeout, retryWaitFunc)
 }
 
-// ListEvents retrieves events for the object with the given name.
-func ListEvents(c clientset.Interface, namespace string, name string, options ...*APICallOptions) (obj *apiv1.EventList, err error) {
+func ListEventsWithOptions(c clientset.Interface, namespace string, listOptions metav1.ListOptions, options ...*APICallOptions) (obj *apiv1.EventList, err error) {
 	getFunc := func() error {
-		obj, err = c.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{
-			FieldSelector: "involvedObject.name=" + name,
-		})
+		obj, err = c.CoreV1().Events(namespace).List(context.TODO(), listOptions)
 		return err
 	}
 	if err := RetryWithExponentialBackOff(RetryFunction(getFunc, options...)); err != nil {
 		return nil, err
 	}
 	return obj, nil
+}
+
+// ListEvents retrieves events for the object with the given name.
+func ListEvents(c clientset.Interface, namespace string, name string, options ...*APICallOptions) (obj *apiv1.EventList, err error) {
+	return ListEventsWithOptions(c, namespace, metav1.ListOptions{
+		FieldSelector: "involvedObject.name=" + name,
+	}, options...)
 }
 
 // DeleteStorageClass deletes storage class with given name.

--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
@@ -93,6 +94,15 @@ func newFramework(clusterConfig *config.ClusterConfig, clientsNumber int, kubeCo
 	}
 
 	return &f, nil
+}
+
+func NewFakeFramework(fakeClient clientset.Interface) *Framework {
+	return &Framework{
+		automanagedNamespaces: make(map[string]bool),
+		clientSets: &MultiClientSet{
+			clients: []clientset.Interface{fakeClient},
+		},
+	}
 }
 
 // GetAutomanagedNamespacePrefix returns automanaged namespace prefix.

--- a/clusterloader2/pkg/measurement/common/job_lifecycle_latency_test.go
+++ b/clusterloader2/pkg/measurement/common/job_lifecycle_latency_test.go
@@ -1,0 +1,226 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/perf-tests/clusterloader2/pkg/framework"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+)
+
+func TestJobLifecycleLatencyMeasurement(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	m := createJobLifecycleLatencyMeasurement().(*jobLifecycleLatencyMeasurement)
+	m.eventTicker.Reset(time.Second)
+
+	startConfig := &measurement.Config{
+		Params: map[string]interface{}{
+			"action": "start",
+		},
+		ClusterFramework: framework.NewFakeFramework(client),
+	}
+	if _, err := m.Execute(startConfig); err != nil {
+		t.Fatalf("Failed to start measurement: %v", err)
+	}
+
+	start := time.Now()
+	namespace := "default"
+	jobs := []batchv1.Job{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Job",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "job0",
+				Namespace:         namespace,
+				CreationTimestamp: metav1.Time{Time: start},
+			},
+			Status: batchv1.JobStatus{
+				StartTime:      &metav1.Time{Time: start.Add(1 * time.Minute)},
+				CompletionTime: &metav1.Time{Time: start.Add(2 * time.Minute)},
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Job",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "job1",
+				Namespace:         namespace,
+				CreationTimestamp: metav1.Time{Time: start.Add(30 * time.Second)},
+			},
+			Status: batchv1.JobStatus{
+				StartTime:      &metav1.Time{Time: start.Add(2 * time.Minute)},
+				CompletionTime: &metav1.Time{Time: start.Add(4 * time.Minute)},
+			},
+		},
+	}
+	for _, job := range jobs {
+		if _, err := client.BatchV1().Jobs(namespace).Create(context.TODO(), &job, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create job: %v", err)
+		}
+	}
+
+	events := []corev1.Event{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Event",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "event0",
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Name:      "job0",
+				Namespace: namespace,
+			},
+			Reason:         "SuccessfulCreate",
+			Message:        "Created pod: pod0",
+			FirstTimestamp: metav1.Time{Time: start.Add(2 * time.Minute)},
+			LastTimestamp:  metav1.Time{Time: start.Add(2 * time.Minute)},
+			Count:          1,
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Event",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "event1",
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Name:      "job1",
+				Namespace: namespace,
+			},
+			Reason:         "SuccessfulCreate",
+			Message:        "Created pod: pod1",
+			FirstTimestamp: metav1.Time{Time: start.Add(5 * time.Minute)},
+			LastTimestamp:  metav1.Time{Time: start.Add(5 * time.Minute)},
+			Count:          1,
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Event",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "event2",
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Name:      "job1",
+				Namespace: namespace,
+			},
+			Reason:         "SuccessfulCreate",
+			Message:        "(combined from similar events): Created pod: pod2",
+			FirstTimestamp: metav1.Time{Time: start.Add(time.Minute)},
+			LastTimestamp:  metav1.Time{Time: start.Add(6 * time.Minute)},
+			Count:          11,
+		},
+	}
+	for _, event := range events {
+		_, err := client.CoreV1().Events(namespace).Create(context.TODO(), &event, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create event: %v", err)
+		}
+	}
+
+	time.Sleep(2 * time.Second)
+
+	gatherConfig := &measurement.Config{
+		Identifier: "test",
+		Params: map[string]interface{}{
+			"action": "gather",
+		},
+		ClusterFramework: framework.NewFakeFramework(client),
+	}
+	summaries, err := m.Execute(gatherConfig)
+	if err != nil {
+		t.Fatalf("Failed to gather measurement: %v", err)
+	}
+
+	if len(summaries) != 1 {
+		t.Fatalf("Expect 1 summary, got %d", len(summaries))
+	}
+	summary := summaries[0]
+	if summary.SummaryName() != "JobLifecycleLatency_test" {
+		t.Errorf("Unexpected summary name: %s", summary.SummaryName())
+	}
+	var perfData map[string]interface{}
+	if err := json.Unmarshal([]byte(summary.SummaryContent()), &perfData); err != nil {
+		t.Fatalf("Failed to parse summary content as JSON: %v", err)
+	}
+
+	{
+		createToPodStart := findDataItem(perfData, "create_to_pod_start")
+		if createToPodStart == nil {
+			t.Fatalf("Missing create_to_pod_start in summary")
+		}
+		gotP50 := getMetric(createToPodStart, "Perc50")
+		if gotP50 != 3*time.Minute {
+			t.Errorf("Expect create_to_pod_start Perc50 = 3 minutes, got %v", gotP50)
+		}
+		gotP90 := getMetric(createToPodStart, "Perc90")
+		if gotP90 != 5*time.Minute {
+			t.Errorf("Expect create_to_pod_start Perc90 = 5 minutes, got %v", gotP90)
+		}
+		gotP99 := getMetric(createToPodStart, "Perc99")
+		if gotP99 != 5*time.Minute+30*time.Second {
+			t.Errorf("Expect create_to_pod_start Perc99 = 5.5 minutes, got %v", gotP99)
+		}
+	}
+	{
+		createToStart := findDataItem(perfData, "create_to_start")
+		if createToStart == nil {
+			t.Fatalf("Missing create_to_start in summary")
+		}
+		gotP50 := getMetric(createToStart, "Perc50")
+		if gotP50 != time.Minute {
+			t.Errorf("Expect create_to_start Perc50 = 1 minute, got %v", gotP50)
+		}
+		gotP90 := getMetric(createToStart, "Perc90")
+		if gotP90 != time.Minute+30*time.Second {
+			t.Errorf("Expect create_to_start Perc90 = 1.5 minutes, got %v", gotP90)
+		}
+		gotP99 := getMetric(createToStart, "Perc99")
+		if gotP99 != time.Minute+30*time.Second {
+			t.Errorf("Expect create_to_start Perc99 = 1.5 minutes, got %v", gotP99)
+		}
+	}
+	{
+		startToComplete := findDataItem(perfData, "start_to_complete")
+		if startToComplete == nil {
+			t.Fatalf("Missing start_to_complete in summary")
+		}
+		gotP50 := getMetric(startToComplete, "Perc50")
+		if gotP50 != time.Minute {
+			t.Errorf("Expect start_to_complete Perc50 = 1 minutes, got %v", gotP50)
+		}
+		gotP90 := getMetric(startToComplete, "Perc90")
+		if gotP90 != 2*time.Minute {
+			t.Errorf("Expect start_to_complete Perc90 = 2 minutes, got %v", gotP90)
+		}
+		gotP99 := getMetric(startToComplete, "Perc99")
+		if gotP99 != 2*time.Minute {
+			t.Errorf("Expect start_to_complete Perc99 = 2 minutes, got %v", gotP99)
+		}
+	}
+}
+
+func findDataItem(perfData map[string]interface{}, name string) map[string]interface{} {
+	dataItems := perfData["dataItems"].([]interface{})
+	for _, item := range dataItems {
+		casted := item.(map[string]interface{})
+		labels := casted["labels"].(map[string]interface{})
+		if labels["Metric"] == name {
+			return casted
+		}
+	}
+	return nil
+}
+
+func getMetric(dataItem map[string]interface{}, metric string) time.Duration {
+	return time.Duration(dataItem["data"].(map[string]interface{})[metric].(float64)) * time.Millisecond
+}

--- a/clusterloader2/pkg/measurement/util/cron.go
+++ b/clusterloader2/pkg/measurement/util/cron.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "time"
+
+func RunEveryTick(ticker *time.Ticker, task func(), stop <-chan struct{}) {
+	defer func() {
+		ticker.Stop()
+	}()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			task()
+		}
+	}
+}

--- a/clusterloader2/pkg/measurement/util/cron_test.go
+++ b/clusterloader2/pkg/measurement/util/cron_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+type mockTicker struct {
+	C   chan time.Time
+	now time.Time
+}
+
+func newMockTicker() *mockTicker {
+	return &mockTicker{
+		C:   make(chan time.Time, 5),
+		now: time.Now(),
+	}
+}
+
+func (t *mockTicker) tick() {
+	t.now = t.now.Add(time.Minute)
+	t.C <- t.now
+}
+
+func TestRunEveryTick(t *testing.T) {
+	tests := []struct {
+		name     string
+		stop     bool
+		expected int
+	}{
+		{
+			name:     "WithoutStop",
+			stop:     false,
+			expected: 2,
+		},
+		{
+			name:     "WithStop",
+			stop:     true,
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			counter := 0
+			increase := func() {
+				counter++
+			}
+			ticker := newMockTicker()
+			stop := make(chan struct{})
+			go RunEveryTick(&time.Ticker{C: ticker.C}, increase, stop)
+
+			ticker.tick()
+			runtime.Gosched()
+
+			if tt.stop {
+				close(stop)
+				runtime.Gosched()
+			}
+
+			ticker.tick()
+			runtime.Gosched()
+
+			if counter != tt.expected {
+				t.Errorf("Expect counter to be %d, got %d", tt.expected, counter)
+			}
+		})
+	}
+}

--- a/clusterloader2/pkg/measurement/util/phase_latency_test.go
+++ b/clusterloader2/pkg/measurement/util/phase_latency_test.go
@@ -1,0 +1,88 @@
+package util
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestObjectTransitionTimesIterator(t *testing.T) {
+	ott := NewObjectTransitionTimes("test")
+	ott.Set("obj0", "phase1", time.Now())
+	ott.Set("obj1", "phase1", time.Now())
+	ott.Set("obj2", "phase1", time.Now())
+
+	var objects []string
+	for obj := range ott.Keys() {
+		objects = append(objects, obj)
+	}
+
+	if len(objects) != 3 {
+		t.Errorf("expect 3 objects, got %d", len(objects))
+	}
+
+	sort.Strings(objects)
+	for i := 0; i < 3; i++ {
+		expected := fmt.Sprintf("obj%d", i)
+		if objects[i] != expected {
+			t.Errorf("expect %q at index %d, got %q", expected, i, objects[i])
+		}
+	}
+}
+
+func TestPodCreationEventTimes(t *testing.T) {
+	start := time.Now()
+	pcet := NewPodCreationEventTimes()
+	pcet.Set(
+		"default/job0",
+		&corev1.Event{
+			InvolvedObject: corev1.ObjectReference{
+				Name: "job0",
+			},
+			Message:        "Created pod: pod0",
+			FirstTimestamp: metav1.Time{Time: start.Add(2 * time.Minute)},
+			LastTimestamp:  metav1.Time{Time: start.Add(2 * time.Minute)},
+			Count:          1,
+		})
+	pcet.Set(
+		"default/job1",
+		&corev1.Event{
+			InvolvedObject: corev1.ObjectReference{
+				Name: "job1",
+			},
+			Message:        "Created pod: pod1",
+			FirstTimestamp: metav1.Time{Time: start.Add(5 * time.Minute)},
+			LastTimestamp:  metav1.Time{Time: start.Add(5 * time.Minute)},
+			Count:          1,
+		})
+	pcet.Set(
+		"default/job1",
+		&corev1.Event{
+			InvolvedObject: corev1.ObjectReference{
+				Name: "job1",
+			},
+			Message:        "(combined from similar events): Created pod: pod2",
+			FirstTimestamp: metav1.Time{Time: start.Add(time.Minute)},
+			LastTimestamp:  metav1.Time{Time: start.Add(6 * time.Minute)},
+			Count:          11,
+		})
+
+	jobCreationTimes := map[string]time.Time{
+		"default/job0": start,
+		"default/job1": start.Add(30 * time.Second),
+	}
+	latencyMetric := pcet.CalculateLatency(jobCreationTimes)
+	if latencyMetric.Perc50 != 3*time.Minute {
+		t.Errorf("expected Perc50 = 3 minutes, got %v", latencyMetric.Perc50)
+	}
+	if latencyMetric.Perc90 != 5*time.Minute {
+		t.Errorf("expected Perc90 = 5 minutes, got %v", latencyMetric.Perc90)
+	}
+	if latencyMetric.Perc99 != 5*time.Minute+30*time.Second {
+		t.Errorf("expected Perc99 = 5.5 minutes, got %v", latencyMetric.Perc99)
+	}
+}


### PR DESCRIPTION
 #### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add a metric to measure latency from job creation to pod creation in JobLifecycleLatency.

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:
Passed unit tests
```
$ go test ./...
ok      k8s.io/perf-tests/clusterloader2/api    (cached)
?       k8s.io/perf-tests/clusterloader2/cmd    [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/chaos      [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/errors     [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/execservice        [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/flags      [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/framework  [no test files]
ok      k8s.io/perf-tests/clusterloader2/pkg/config     (cached)
?       k8s.io/perf-tests/clusterloader2/pkg/framework/config   [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/imagepreload       [no test files]
ok      k8s.io/perf-tests/clusterloader2/pkg/framework/client   (cached)
?       k8s.io/perf-tests/clusterloader2/pkg/measurement        [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle  [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/common/dns     [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/common/executors       [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/common/metrics [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/common/network [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/common/network-policy  [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/common/probes  [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/util/checker   [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/util/gatherers [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer  [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/util/kubelet   [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/util/kubemark  [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue       [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/metadata   [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/provider   [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/state      [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/test       [no test files]
?       k8s.io/perf-tests/clusterloader2/pkg/tuningset  [no test files]
ok      k8s.io/perf-tests/clusterloader2/pkg/measurement/common 5.871s
ok      k8s.io/perf-tests/clusterloader2/pkg/measurement/common/slos    5.515s
ok      k8s.io/perf-tests/clusterloader2/pkg/measurement/util   (cached)
ok      k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects    (cached)
ok      k8s.io/perf-tests/clusterloader2/pkg/modifier   (cached)
ok      k8s.io/perf-tests/clusterloader2/pkg/prometheus (cached)
ok      k8s.io/perf-tests/clusterloader2/pkg/util       (cached)
```