### PR TITLE
Add option to filter for agentpool label in containerd scrape config

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-containerd-scrape-configs.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-containerd-scrape-configs.yaml
@@ -23,3 +23,5 @@ stringData:
         target_label: __address__
       - source_labels: [instance]
         target_label: node
+      - source_labels: [__meta_kubernetes_node_label_agentpool]
+        target_label: nodepool


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add option to scrape agentpool label. If the label doesn't exist, it'll just get ignored

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

