### PR TITLE
fix: refactor iperf test cases 13 through 16 to use default runners

### DIFF
--- a/network/benchmarks/netperf/nptest/tests.go
+++ b/network/benchmarks/netperf/nptest/tests.go
@@ -204,54 +204,50 @@ var testcases = []*TestCase{
 		Type:            netperfTest,
 	},
 	{
-		Label: "13 iperf Throughput TCP. Same VM using Pod IP",
+		Label: "13 iperf Default TCP. Same VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       false,
 			TestDuration:    10 * time.Minute,
-			Bandwidth:       "1G",
 		},
-		TestRunner: iperfThroughputTcpRunner,
+		TestRunner: defaultIperfTCPRunner,
 		JsonParser: parsers.ParseIperfTcpResults,
 		Type:       iperfThroughputTest,
 	},
 	{
-		Label: "14 iperf Throughput TCP. Remote VM using Pod IP",
+		Label: "14 iperf Default TCP. Remote VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w3",
 			ClusterIP:       false,
 			TestDuration:    10 * time.Minute,
-			Bandwidth:       "1G",
 		},
-		TestRunner: iperfThroughputTcpRunner,
+		TestRunner: defaultIperfTCPRunner,
 		JsonParser: parsers.ParseIperfTcpResults,
 		Type:       iperfThroughputTest,
 	},
 	{
-		Label: "15 iperf Throughput UDP. Remote VM using Pod IP",
+		Label: "15 iperf Default UDP. Remote VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w3",
 			ClusterIP:       false,
 			TestDuration:    10 * time.Minute,
-			Bandwidth:       "1G",
 		},
-		TestRunner: iperfThroughputUdpRunner,
+		TestRunner: defaultIperfUDPRunner,
 		JsonParser: parsers.ParseIperfUdpResults,
 		Type:       iperfThroughputUDPTest,
 	},
 	{
-		Label: "16 iperf Throughput UDP. Same VM using Pod IP",
+		Label: "16 iperf Default UDP. Same VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       false,
 			TestDuration:    10 * time.Minute,
-			Bandwidth:       "1G",
 		},
-		TestRunner: iperfThroughputUdpRunner,
+		TestRunner: defaultIperfUDPRunner,
 		JsonParser: parsers.ParseIperfUdpResults,
 		Type:       iperfThroughputUDPTest,
 	},
@@ -272,12 +268,13 @@ func netperfTestRunner(w ClientWorkItem) string {
 	return output
 }
 
-func iperfThroughputTcpRunner(w ClientWorkItem) string {
-	output, _ := cmdExec(iperf3Path, []string{iperf3Path, "-c", w.Host, "-V", "-J", "--time", fmt.Sprintf("%f", w.Params.TestDuration.Seconds()), "--bandwidth", w.Params.Bandwidth, "-w", "410K", "-P", "1"}, 15)
+// TODO: Implement a common pattern to run iperf3 command and re utilize them
+func defaultIperfTCPRunner(w ClientWorkItem) string {
+	output, _ := cmdExec(iperf3Path, []string{iperf3Path, "-c", w.Host, "-V", "-J", "--time", fmt.Sprintf("%f", w.Params.TestDuration.Seconds())}, 15)
 	return output
 }
 
-func iperfThroughputUdpRunner(w ClientWorkItem) string {
-	output, _ := cmdExec(iperf3Path, []string{iperf3Path, "-c", w.Host, "-V", "-J", "--time", fmt.Sprintf("%f", w.Params.TestDuration.Seconds()), "--bandwidth", w.Params.Bandwidth, "-w", "410K", "-P", "1", "-u"}, 15)
+func defaultIperfUDPRunner(w ClientWorkItem) string {
+	output, _ := cmdExec(iperf3Path, []string{iperf3Path, "-c", w.Host, "-V", "-J", "--time", fmt.Sprintf("%f", w.Params.TestDuration.Seconds()), "-u"}, 15)
 	return output
 }


### PR DESCRIPTION
Changes are made to remove the bandwidth limit for the tests we perform.

This pull request includes changes to the `network/benchmarks/netperf/nptest/tests.go` file to update the test case labels and replace specific iperf test runners with default ones.

Updates to test case labels and runners:

* Changed labels for test cases 13 to 16 to use "Default" instead of "Throughput" for both TCP and UDP tests.
* Replaced `iperfThroughputTcpRunner` with `defaultIperfTCPRunner` and `iperfThroughputUdpRunner` with `defaultIperfUDPRunner` in test cases 13 to 16.

Addition of default iperf test runners:

* Added the `defaultIperfTCPRunner` function to run default TCP tests.
* Added the `defaultIperfUDPRunner` function to run default UDP tests.
