### PR TITLE
refactor: remove unused context import in netperf launch.go

### DIFF
--- a/network/benchmarks/netperf/launch.go
+++ b/network/benchmarks/netperf/launch.go
@@ -27,7 +27,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"


### PR DESCRIPTION
This pull request includes a minor change to the `network/benchmarks/netperf/launch.go` file. The change removes an unused import statement for `context`.

* [`network/benchmarks/netperf/launch.go`](diffhunk://#diff-6f19456e92323e367eebea98fd85d080c614d7e6c0e0351dd3178a5a481b9e8aL30): Removed the unused import statement for `context`.