### PR TITLE
fix: set bandwidth to unlimited in default Iperf UDP runner

### DIFF
--- a/network/benchmarks/netperf/nptest/tests.go
+++ b/network/benchmarks/netperf/nptest/tests.go
@@ -275,6 +275,6 @@ func defaultIperfTCPRunner(w ClientWorkItem) string {
 }
 
 func defaultIperfUDPRunner(w ClientWorkItem) string {
-	output, _ := cmdExec(iperf3Path, []string{iperf3Path, "-c", w.Host, "-V", "-J", "--time", fmt.Sprintf("%f", w.Params.TestDuration.Seconds()), "-u"}, 15)
+	output, _ := cmdExec(iperf3Path, []string{iperf3Path, "-c", w.Host, "-V", "-J", "--time", fmt.Sprintf("%f", w.Params.TestDuration.Seconds()), "-u", "-b", "0"}, 15)
 	return output
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `defaultIperfUDPRunner` function in the `network/benchmarks/netperf/nptest/tests.go` file. The change ensures that the UDP bandwidth is set to unlimited by adding the `-b 0` flag to the `iperf3` command.

* [`network/benchmarks/netperf/nptest/tests.go`](diffhunk://#diff-e54914562b4f5cace63e56073af3a12d1694c76d43e796fb376471ab5575ceeaL278-R278): Added the `-b 0` flag to the `iperf3` command in the `defaultIperfUDPRunner` function to set the UDP bandwidth to unlimited.