### PR TITLE
Enable countErrorMargin parameter for  waitForRunningPodsMeasurement.

### DIFF
--- a/clusterloader2/Dockerfile
+++ b/clusterloader2/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.24
 FROM golang:${GOLANG_VERSION} AS builder
 
 WORKDIR /root/perf-tests/clusterloader2

--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -30,6 +30,7 @@ import (
 const (
 	defaultWaitForPodsTimeout         = 60 * time.Second
 	defaultWaitForPodsInterval        = 5 * time.Second
+	defaultCountErrorMargin           = 0
 	defaultIsFatal                    = false
 	waitForRunningPodsMeasurementName = "WaitForRunningPods"
 )
@@ -51,6 +52,10 @@ type waitForRunningPodsMeasurement struct{}
 // If namespace is not passed by parameter, all-namespace scope is assumed.
 func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
 	desiredPodCount, err := util.GetInt(config.Params, "desiredPodCount")
+	if err != nil {
+		return nil, err
+	}
+	countErrorMargin, err := util.GetIntOrDefault(config.Params, "countErrorMargin", defaultCountErrorMargin)
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +81,7 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 	defer cancel()
 	options := &measurementutil.WaitForPodOptions{
 		DesiredPodCount:     func() int { return desiredPodCount },
+		CountErrorMargin:    countErrorMargin,
 		CallerName:          w.String(),
 		WaitForPodsInterval: refreshInterval,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We are enabling the `countErrorMargin` parameter in the `waitForRunningPodsMeasurement` to be set by the user.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

