### PR TITLE
Drop kwok nodes in kubelet metrics

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubelet.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubelet.yaml
@@ -19,6 +19,10 @@ spec:
     bearerTokenSecret:
       name: prometheus-token
       key: token
+    relabelings:
+      - sourceLabels: [ __meta_kubernetes_endpoint_node_name ]
+        regex: 'kwok-.*'
+        action: drop
   - port: https-metrics
     scheme: https
     path: /metrics/cadvisor
@@ -29,6 +33,10 @@ spec:
     bearerTokenSecret:
       name: prometheus-token
       key: token
+    relabelings:
+      - sourceLabels: [ __meta_kubernetes_endpoint_node_name ]
+        regex: 'kwok-.*'
+        action: drop
     metricRelabelings:
       - sourceLabels: [ namespace ]
         regex: 'test-.*'


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This pull request updates the Prometheus ServiceMonitor configuration for kubelets to improve how targets are selected for monitoring. The main change is the addition of relabeling rules that exclude nodes with names matching the pattern `kwok-*` from being scraped.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer: