### PR TITLE
Update WaitForGenericK8sObjects measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
@@ -83,6 +83,12 @@ func (w *waitForGenericK8sObjectsMeasurement) Execute(config *measurement.Config
 	if err != nil {
 		return nil, err
 	}
+	// maxDesiredObjectCount enables deletion mode when >= 0.
+	// Default is -1 (disabled), preserving the original condition-based behavior.
+	maxDesiredObjectCount, err := util.GetIntOrDefault(config.Params, "maxDesiredObjectCount", -1)
+	if err != nil {
+		return nil, err
+	}
 
 	dynamicClient := config.ClusterFramework.GetDynamicClients().GetClient()
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
@@ -95,6 +101,7 @@ func (w *waitForGenericK8sObjectsMeasurement) Execute(config *measurement.Config
 		FailedConditions:      failedConditions,
 		MinDesiredObjectCount: minDesiredObjectCount,
 		MaxFailedObjectCount:  maxFailedObjectCount,
+		MaxDesiredObjectCount: maxDesiredObjectCount,
 		CallerName:            w.String(),
 		WaitInterval:          refreshInterval,
 	}

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions.go
@@ -45,6 +45,10 @@ type WaitForGenericK8sObjectsOptions struct {
 	MinDesiredObjectCount int
 	// MaxFailedObjectCount describes maximum number of objects that could contain failed condition.
 	MaxFailedObjectCount int
+	// MaxDesiredObjectCount, if non-negative, switches to deletion mode:
+	// the measurement waits until the total object count drops to this value
+	// or below. When set, condition-based fields are ignored.
+	MaxDesiredObjectCount int
 	// CallerName identifies the measurement making the calls.
 	CallerName string
 	// WaitInterval contains interval for which the function waits between refreshes.
@@ -80,12 +84,45 @@ func (nr *NamespacesRange) getMap() map[string]bool {
 // WaitForGenericK8sObjects waits till the desired number of k8s objects
 // fulfills given conditions requirements, ctx.Done() channel is used to
 // wait for timeout.
+// When MaxDesiredObjectCount is non-negative, the function switches to
+// deletion mode and waits until the total object count drops to that value
+// or below.
 func WaitForGenericK8sObjects(ctx context.Context, dynamicClient dynamic.Interface, options *WaitForGenericK8sObjectsOptions) error {
 	store, err := NewDynamicObjectStore(ctx, dynamicClient, options.GroupVersionResource, options.Namespaces.getMap())
 	if err != nil {
 		return err
 	}
 
+	if options.MaxDesiredObjectCount >= 0 {
+		return waitForObjectDeletion(ctx, store, options)
+	}
+	return waitForObjectConditions(ctx, store, options)
+}
+
+// waitForObjectDeletion waits until the total number of objects drops to
+// MaxDesiredObjectCount or below.
+func waitForObjectDeletion(ctx context.Context, store *DynamicObjectStore, options *WaitForGenericK8sObjectsOptions) error {
+	for {
+		objects, err := store.ListObjectSimplifications()
+		if err != nil {
+			return err
+		}
+		count := len(objects)
+		klog.V(2).Infof("%s: waiting for object count to drop to %d, current count=%d", options.Summary(), options.MaxDesiredObjectCount, count)
+		if count <= options.MaxDesiredObjectCount {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: timeout while waiting for object count to drop to %d, current count=%d",
+				options.Summary(), options.MaxDesiredObjectCount, count)
+		case <-time.After(options.WaitInterval):
+		}
+	}
+}
+
+// waitForObjectConditions waits until enough objects match the given conditions.
+func waitForObjectConditions(ctx context.Context, store *DynamicObjectStore, options *WaitForGenericK8sObjectsOptions) error {
 	objects, err := store.ListObjectSimplifications()
 	if err != nil {
 		return err

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
@@ -55,6 +55,7 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 				FailedConditions:      []string{},
 				MinDesiredObjectCount: 1,
 				MaxFailedObjectCount:  0,
+				MaxDesiredObjectCount: -1,
 				CallerName:            "test",
 				WaitInterval:          100 * time.Millisecond,
 			},
@@ -85,6 +86,7 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 				FailedConditions:      []string{"Failed=True"},
 				MinDesiredObjectCount: 1,
 				MaxFailedObjectCount:  0,
+				MaxDesiredObjectCount: -1,
 				CallerName:            "test",
 				WaitInterval:          100 * time.Millisecond,
 			},
@@ -120,6 +122,7 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 				FailedConditions:      []string{"Failed=True"},
 				MinDesiredObjectCount: 3,
 				MaxFailedObjectCount:  1,
+				MaxDesiredObjectCount: -1,
 				CallerName:            "test",
 				WaitInterval:          100 * time.Millisecond,
 			},
@@ -166,6 +169,7 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 				FailedConditions:      []string{"Failed=True"},
 				MinDesiredObjectCount: 3,
 				MaxFailedObjectCount:  1,
+				MaxDesiredObjectCount: -1,
 				CallerName:            "test",
 				WaitInterval:          100 * time.Millisecond,
 			},
@@ -198,6 +202,113 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 			defer cancel()
 			dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
 				tt.options.GroupVersionResource: "ConditionsList",
+			})
+			for _, o := range tt.existingObjects {
+				c := dynamicClient.Resource(tt.options.GroupVersionResource).Namespace(o.Namespace)
+				if _, err := c.Create(ctx, o.Unstructured, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create an existing object %v, got error: %v", o, err)
+				}
+			}
+
+			if err := WaitForGenericK8sObjects(ctx, dynamicClient, tt.options); (err != nil) != tt.wantErr {
+				t.Errorf("WaitForGenericK8sObjects() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWaitForGenericK8sObjectsDeletion(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "ray.io",
+		Version:  "v1",
+		Resource: "rayclusters",
+	}
+
+	tests := []struct {
+		name            string
+		timeout         time.Duration
+		options         *WaitForGenericK8sObjectsOptions
+		existingObjects []exampleObject
+		wantErr         bool
+	}{
+		{
+			name:    "no objects remaining, deletion complete",
+			timeout: 2 * time.Second,
+			options: &WaitForGenericK8sObjectsOptions{
+				GroupVersionResource:  gvr,
+				Namespaces:            NamespacesRange{Prefix: "namespace", Min: 1, Max: 1},
+				MaxDesiredObjectCount: 0,
+				CallerName:            "test",
+				WaitInterval:          100 * time.Millisecond,
+			},
+			existingObjects: []exampleObject{},
+			wantErr:         false,
+		},
+		{
+			name:    "objects still present, exceeds max desired",
+			timeout: 1 * time.Second,
+			options: &WaitForGenericK8sObjectsOptions{
+				GroupVersionResource:  gvr,
+				Namespaces:            NamespacesRange{Prefix: "namespace", Min: 1, Max: 1},
+				MaxDesiredObjectCount: 0,
+				CallerName:            "test",
+				WaitInterval:          100 * time.Millisecond,
+			},
+			existingObjects: []exampleObject{
+				newExampleObject("raycluster-1", "namespace-1", []interface{}{}),
+				newExampleObject("raycluster-2", "namespace-1", []interface{}{}),
+			},
+			wantErr: true,
+		},
+		{
+			name:    "object count at max desired threshold",
+			timeout: 2 * time.Second,
+			options: &WaitForGenericK8sObjectsOptions{
+				GroupVersionResource:  gvr,
+				Namespaces:            NamespacesRange{Prefix: "namespace", Min: 1, Max: 1},
+				MaxDesiredObjectCount: 2,
+				CallerName:            "test",
+				WaitInterval:          100 * time.Millisecond,
+			},
+			existingObjects: []exampleObject{
+				newExampleObject("raycluster-1", "namespace-1", []interface{}{}),
+				newExampleObject("raycluster-2", "namespace-1", []interface{}{}),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "negative maxDesiredObjectCount uses condition mode, not deletion",
+			timeout: 1 * time.Second,
+			options: &WaitForGenericK8sObjectsOptions{
+				GroupVersionResource:  gvr,
+				Namespaces:            NamespacesRange{Prefix: "namespace", Min: 1, Max: 1},
+				SuccessfulConditions:  []string{"Ready=True"},
+				FailedConditions:      []string{},
+				MinDesiredObjectCount: 1,
+				MaxFailedObjectCount:  0,
+				MaxDesiredObjectCount: -1,
+				CallerName:            "test",
+				WaitInterval:          100 * time.Millisecond,
+			},
+			existingObjects: []exampleObject{
+				newExampleObject("raycluster-1", "namespace-1", []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+				}),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
+			defer cancel()
+			dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+				tt.options.GroupVersionResource: "RayClusterList",
 			})
 			for _, o := range tt.existingObjects {
 				c := dynamicClient.Resource(tt.options.GroupVersionResource).Namespace(o.Namespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This pull request adds a new "deletion mode" to the `WaitForGenericK8sObjects` measurement, allowing tests to wait for the total number of objects to drop to a specified threshold (`MaxDesiredObjectCount`). When this parameter is set to a non-negative value, the measurement ignores condition-based fields and waits for object deletion instead. The PR also includes unit tests for the new functionality and ensures backward compatibility by defaulting the new parameter to disabled.

**Enhancements to object waiting logic:**

* Added a new `MaxDesiredObjectCount` parameter to `WaitForGenericK8sObjectsOptions` and related measurement logic. When set to a non-negative value, the measurement waits until the total object count drops to this value or below, switching from condition-based checks to deletion mode. [[1]](diffhunk://#diff-45a4836acaa50290a9c27244d8d75020f7a9634c4d673708d12d15c8217fb9fbR48-R51) [[2]](diffhunk://#diff-6ccd1961c3b540887a5494d10cc9085323563ed6f785f38ba6c33eeede5d8454R86-R91) [[3]](diffhunk://#diff-6ccd1961c3b540887a5494d10cc9085323563ed6f785f38ba6c33eeede5d8454R104)
* Updated the implementation in `wait_for_conditions.go` to branch between deletion mode and the original condition-based mode depending on the value of `MaxDesiredObjectCount`. Introduced a new `waitForObjectDeletion` helper function.

**Testing improvements:**

* Added a comprehensive test suite (`TestWaitForGenericK8sObjectsDeletion`) to cover scenarios for the new deletion mode, including cases where the object count is above, at, or below the threshold, and verifying that negative values retain the original behavior.
* Updated existing tests to explicitly set `MaxDesiredObjectCount: -1` to clarify the default/legacy behavior. [[1]](diffhunk://#diff-f12ef5219062ecea16d9f4ba9735440ad9fede03c0011c7d7cc2512bd07c216dR58) [[2]](diffhunk://#diff-f12ef5219062ecea16d9f4ba9735440ad9fede03c0011c7d7cc2512bd07c216dR89) [[3]](diffhunk://#diff-f12ef5219062ecea16d9f4ba9735440ad9fede03c0011c7d7cc2512bd07c216dR125) [[4]](diffhunk://#diff-f12ef5219062ecea16d9f4ba9735440ad9fede03c0011c7d7cc2512bd07c216dR172)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

